### PR TITLE
Updated name to "Cloud Firestore", updated Firebase app versions

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 # Firebase + WebRTC Codelab
-
+### Full code solution can be found under the branch: _solution_
 This is the GitHub repo for the FirebaseRTC codelab. This will teach you how 
 to use Firebase Cloud Firestore for signalling in a WebRTC video chat application.
 

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # Firebase + WebRTC Codelab
 
 This is the GitHub repo for the FirebaseRTC codelab. This will teach you how 
-to use Firebase Cloudstore for signalling in a WebRTC video chat application.
+to use Firebase Cloud Firestore for signalling in a WebRTC video chat application.
 
 The solution to this codelab can be seen in the _solution_ branch.
 

--- a/public/index.html
+++ b/public/index.html
@@ -9,9 +9,9 @@
     <link rel="stylesheet" href="https://fonts.googleapis.com/icon?family=Material+Icons">
 
     <!-- update the version number as needed -->
-    <script defer src="/__/firebase/5.9.3/firebase-app.js"></script>
+    <script defer src="/__/firebase/7.13.1/firebase-app.js"></script>
     <!-- include only the Firebase features as you need -->
-    <script defer src="/__/firebase/5.9.3/firebase-firestore.js"></script>
+    <script defer src="/__/firebase/7.13.1/firebase-firestore.js"></script>
     <!-- initialize the SDK after all desired features are loaded -->
     <script defer src="/__/firebase/init.js"></script>
 


### PR DESCRIPTION
- The Firebase database the codelab uses is called "Cloud Firestore" or just "Firestore", **not** "Cloudstore" as it is mentioned to in the README, as well as the codelab

- Firebase versions were out of date - updated from 5.9.3 to 7.13.1

- Made the code that is complete more easily identifiable on the _solutions_ branch