### PR TITLE
Use batch to delete firestore's data in solution branch

### DIFF
--- a/public/app.js
+++ b/public/app.js
@@ -224,16 +224,18 @@ async function hangUp(e) {
   // Delete room on hangup
   if (roomId) {
     const db = firebase.firestore();
+    const batch = db.batch();
     const roomRef = db.collection('rooms').doc(roomId);
     const calleeCandidates = await roomRef.collection('calleeCandidates').get();
-    calleeCandidates.forEach(async candidate => {
-      await candidate.ref.delete();
+    calleeCandidates.forEach(candidate => {
+      batch.delete(candidate.ref);
     });
     const callerCandidates = await roomRef.collection('callerCandidates').get();
-    callerCandidates.forEach(async candidate => {
-      await candidate.ref.delete();
+    callerCandidates.forEach(candidate => {
+      batch.delete(candidate.ref);
     });
-    await roomRef.delete();
+    batch.delete(roomRef);
+    await batch.commit();
   }
 
   document.location.reload(true);


### PR DESCRIPTION
This is the same as PR #31 , but for solution branch

Hi, I found that the way to delete room data in the code is one-by-one deletion, which will make multiple connections to firestore, causing the deletion speed to be slow.
Therefore, I use the batch deletion method and submit the batch operation at the end, which is much faster , I hope to contribute to the project to make it better.

The following is the link to the data deleted by firestore in batch：
https://firebase.google.com/docs/firestore/manage-data/delete-data?authuser=0#node.js_2